### PR TITLE
Fix resource leaks and capture handling

### DIFF
--- a/ndi/src/find.rs
+++ b/ndi/src/find.rs
@@ -76,13 +76,28 @@ impl FindBuilder {
         }
 
         if let Some(groups) = self.groups {
-            let cstr = CString::new(groups).unwrap();
-            settings.p_groups = cstr.into_raw();
+            let c_groups = CString::new(groups).map_err(|_| FindCreateError)?;
+            settings.p_groups = c_groups.as_ptr();
+
+            if let Some(extra_ips) = self.extra_ips {
+                let c_extra = CString::new(extra_ips).map_err(|_| FindCreateError)?;
+                settings.p_extra_ips = c_extra.as_ptr();
+                let res = Find::with_settings(settings);
+                drop((c_groups, c_extra));
+                return res;
+            } else {
+                let res = Find::with_settings(settings);
+                drop(c_groups);
+                return res;
+            }
         }
 
         if let Some(extra_ips) = self.extra_ips {
-            let cstr = CString::new(extra_ips).unwrap();
-            settings.p_extra_ips = cstr.into_raw();
+            let c_extra = CString::new(extra_ips).map_err(|_| FindCreateError)?;
+            settings.p_extra_ips = c_extra.as_ptr();
+            let res = Find::with_settings(settings);
+            drop(c_extra);
+            return res;
         }
 
         Find::with_settings(settings)

--- a/ndi/src/recv.rs
+++ b/ndi/src/recv.rs
@@ -174,9 +174,13 @@ impl RecvBuilder {
         }
         if let Some(ndi_recv_name) = self.ndi_recv_name {
             // String shouldn't contain a 0-byte
-            let cstr = CString::new(ndi_recv_name).unwrap();
+            let cstr = CString::new(ndi_recv_name).map_err(|_| RecvCreateError)?;
 
-            settings.p_ndi_recv_name = cstr.into_raw();
+            settings.p_ndi_recv_name = cstr.as_ptr();
+            // Ensure CString lives until after the create call
+            let res = Recv::with_settings(settings);
+            drop(cstr);
+            return res;
         }
 
         Recv::with_settings(settings)
@@ -325,28 +329,31 @@ impl Recv {
             )
         };
 
-        if !video.as_ptr().is_null() {
-            *video_data = Some(VideoData::from_binding_recv(
-                self.p_instance.clone(),
-                unsafe { video.assume_init() },
-            ));
+        let frame_type = FrameType::try_from(response).unwrap_or(FrameType::ErrorFrame);
+
+        match frame_type {
+            FrameType::Video => {
+                *video_data = Some(VideoData::from_binding_recv(
+                    self.p_instance.clone(),
+                    unsafe { video.assume_init() },
+                ));
+            }
+            FrameType::Audio => {
+                *audio_data = Some(AudioData::from_binding_recv(
+                    self.p_instance.clone(),
+                    unsafe { audio.assume_init() },
+                ));
+            }
+            FrameType::Metadata => {
+                *meta_data = Some(MetaData::from_binding_recv(
+                    self.p_instance.clone(),
+                    unsafe { metadata.assume_init() },
+                ));
+            }
+            _ => {}
         }
 
-        if !audio.as_ptr().is_null() {
-            *audio_data = Some(AudioData::from_binding_recv(
-                self.p_instance.clone(),
-                unsafe { audio.assume_init() },
-            ));
-        }
-
-        if !metadata.as_ptr().is_null() {
-            *meta_data = Some(MetaData::from_binding_recv(
-                self.p_instance.clone(),
-                unsafe { metadata.assume_init() },
-            ));
-        }
-
-        FrameType::try_from(response).unwrap()
+        frame_type
     }
 
     /// Receive video frame
@@ -366,14 +373,16 @@ impl Recv {
                 timeout_ms,
             );
 
-            if !video.as_ptr().is_null() {
+            let frame_type = FrameType::try_from(response).unwrap_or(FrameType::ErrorFrame);
+
+            if frame_type == FrameType::Video {
                 *video_data = Some(VideoData::from_binding_recv(
                     self.p_instance.clone(),
                     video.assume_init(),
                 ));
             }
 
-            FrameType::try_from(response).unwrap()
+            frame_type
         }
     }
 
@@ -393,13 +402,16 @@ impl Recv {
                 timeout_ms,
             );
 
-            if !audio.as_ptr().is_null() {
+            let frame_type = FrameType::try_from(response).unwrap_or(FrameType::ErrorFrame);
+
+            if frame_type == FrameType::Audio {
                 *audio_data = Some(AudioData::from_binding_recv(
                     self.p_instance.clone(),
                     audio.assume_init(),
                 ));
             }
-            FrameType::try_from(response).unwrap()
+
+            frame_type
         }
     }
 
@@ -419,13 +431,16 @@ impl Recv {
                 timeout_ms,
             );
 
-            if !metadata.as_ptr().is_null() {
+            let frame_type = FrameType::try_from(response).unwrap_or(FrameType::ErrorFrame);
+
+            if frame_type == FrameType::Metadata {
                 *meta_data = Some(MetaData::from_binding_recv(
                     Arc::clone(&self.p_instance),
                     metadata.assume_init(),
                 ));
             }
-            FrameType::try_from(response).unwrap()
+
+            frame_type
         }
     }
 

--- a/ndi/src/send.rs
+++ b/ndi/src/send.rs
@@ -88,12 +88,12 @@ impl SendBuilder {
         let cstr_ndi_group: CString;
 
         if let Some(ndi_name) = self.ndi_name {
-            cstr_ndi_name = CString::new(ndi_name).unwrap();
+            cstr_ndi_name = CString::new(ndi_name).map_err(|_| SendCreateError)?;
             settings.p_ndi_name = cstr_ndi_name.as_ptr();
         }
 
         if let Some(groups) = self.groups {
-            cstr_ndi_group = CString::new(groups).unwrap();
+            cstr_ndi_group = CString::new(groups).map_err(|_| SendCreateError)?;
             settings.p_groups = cstr_ndi_group.as_ptr();
         }
 
@@ -174,9 +174,7 @@ impl Send {
                 p_meta.assume_init(),
             ));
 
-            let res: FrameType = FrameType::try_from(frametype).unwrap();
-
-            res
+            FrameType::try_from(frametype).unwrap_or(FrameType::ErrorFrame)
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid leaking `CString` allocations in `RecvBuilder` and `FindBuilder`
- rely on the returned `FrameType` when building captured frames
- eliminate unwrap calls on FFI inputs for safer handling

## Testing
- `cargo test --workspace --locked --offline` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68527f0bd18c8321ad14714d8c51f568